### PR TITLE
Add simple FastAPI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # playwright-service
 This is a playwright service to support simple test execution of test flows
+
+## FastAPI Setup and Usage
+
+This project includes a simple Python API using FastAPI.
+
+### Requirements
+
+- Python 3.7+
+- FastAPI
+- Uvicorn
+
+### Installation
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/ale-sanchez-g/playwright-service.git
+   cd playwright-service
+   ```
+
+2. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+### Running the FastAPI Server
+
+To run the FastAPI server, use the following command:
+```bash
+uvicorn main:app --reload
+```
+
+The server will be available at `http://127.0.0.1:8000`.
+
+### Endpoints
+
+- **Root Endpoint**: Returns a welcome message.
+  ```http
+  GET /
+  ```
+
+- **Sample Endpoint**: Returns a sample JSON response.
+  ```http
+  GET /sample
+  ```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Welcome to the FastAPI application!"}
+
+@app.get("/sample")
+def read_sample():
+    return {"sample_data": "This is a sample JSON response"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
Add a simple Python API using FastAPI.

* **main.py**: Create a FastAPI instance, define a root endpoint that returns a welcome message, and add a sample endpoint that returns a JSON response.
* **requirements.txt**: Add `fastapi` and `uvicorn` as dependencies.
* **README.md**: Add a section about the FastAPI setup and usage, provide instructions on how to run the FastAPI server, and document the available endpoints.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ale-sanchez-g/playwright-service/pull/1?shareId=8e8b0436-69f1-48dc-80b2-c8217f827982).